### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ package main
 
 import (
 	"bytes"
+	"os"
 
 	"github.com/z7zmey/php-parser/php7"
 	"github.com/z7zmey/php-parser/visitor"
@@ -42,6 +43,7 @@ func main() {
 	nodes, comments, positions := php7.Parse(src, "example.php")
 
 	visitor := visitor.Dumper{
+	        Writer:    os.Stdout,
 		Indent:    "",
 		Comments:  comments,
 		Positions: positions,


### PR DESCRIPTION
Using README example as is throws a nil pointer exception cause Writer in Dumper struct is not defined.