### PR TITLE
the simple fix for #14 (panic on 32-bit)

### DIFF
--- a/scanner/lexer.go
+++ b/scanner/lexer.go
@@ -462,7 +462,7 @@ func Rune2Class(r rune) int {
 
 // NewLexer the Lexer constructor
 func NewLexer(src io.Reader, fName string) *Lexer {
-	file := token.NewFileSet().AddFile(fName, -1, 1<<31-1)
+	file := token.NewFileSet().AddFile(fName, -1, 1<<31-3)
 	lx, err := lex.New(file, bufio.NewReader(src), lex.RuneClass(Rune2Class))
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
  FileSet starts `base` at 1, and adds `size+1` for every file.
  So with 32 bit ints, anything larger than 2³¹-3 overflows.