### PR TITLE
Corrects README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ nodes := &stmt.StmtList{
 
 file := os.Stdout
 p := printer.NewPrinter(file, "    ")
-p.PrintFile(nodes)
+p.Print(nodes)
 ```
 
 It prints to stdout:


### PR DESCRIPTION
.PrintFile doesn't appear to exist on printer.Printer but .Print does and appears to work in the given example.