### PR TITLE
Add `array` to NamespaceResolver

### DIFF
--- a/visitor/namespace_resolver.go
+++ b/visitor/namespace_resolver.go
@@ -315,6 +315,8 @@ func (ns *Namespace) ResolveName(nameNode node.Node, aliasType string) (string, 
 				fallthrough
 			case "iterable":
 				fallthrough
+			case "array":
+				fallthrough
 			case "object":
 				return part, nil
 			}


### PR DESCRIPTION
After browsing through `namespace_resolver.go` I found that `array` is missing as built-in return type. Is it correct to add it here? Or is there a reason that it's not there?