### PR TITLE
if not have file arg, will print usage

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,6 +44,11 @@ func main() {
 
 	flag.Parse()
 
+	if len(flag.Args()) == 0{
+		flag.Usage()
+		return
+	}
+
 	switch profiler {
 	case "cpu":
 		defer profile.Start(profile.ProfilePath("."), profile.NoShutdownHook).Stop()


### PR DESCRIPTION
If  forget to enter the parameters,  should output a friendly usage instead of no response.