### PR TITLE
#111 NamespaceResolver: Resolve PHP 7.4 class property types

### DIFF
--- a/visitor/namespace_resolver.go
+++ b/visitor/namespace_resolver.go
@@ -111,6 +111,11 @@ func (nsr *NamespaceResolver) EnterNode(w walker.Walkable) bool {
 			nsr.ResolveType(n.ReturnType)
 		}
 
+	case *stmt.PropertyList:
+		if n.Type != nil {
+			nsr.ResolveType(n.Type)
+		}
+
 	case *expr.Closure:
 		for _, parameter := range n.Params {
 			nsr.ResolveType(parameter.(*node.Parameter).VariableType)


### PR DESCRIPTION
This PR adds support for PHP 7.4 typed class properties to `NamespaceResolver`.

Fixes #111